### PR TITLE
Add missing \script{} command

### DIFF
--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -41,6 +41,7 @@ For $19784$ stars, or $\sim3.5\%$ of the sample, the astroNN [Fe/H] abundance es
     \includegraphics{figures/delay_time_distributions.pdf}
     \caption{Delay time distribution functions}
     \label{fig:dtds}
+    \script{delay_time_distributions.py}
 \end{figure}
 
 \citet{Schonrich2009-RadialMixing} take their DTD to be an exponential with a 1.5 Gyr timescale, though this isn't strictly observationally motivated.


### PR DESCRIPTION
Need to add \script{} now within figure environments for showyourwork to run the figure script.